### PR TITLE
reduce test warnings due to jim, prompt

### DIFF
--- a/src/fbp/image_geom.jl
+++ b/src/fbp/image_geom.jl
@@ -114,7 +114,7 @@ function image_geom_help( ; io::IO = isinteractive() ? stdout : devnull)
 				i: (ix,iy[,iz]) index from 1 to nx,ny
 				c: (cx,cy[,cz]) index from +/- n/2 center at floor(n/2)+1
 	circ(rx=,ry=,cx=,cy=)	circle of given radius and center (cylinder in 3D)
-	plot(jim)	plot the image geometry using the `jim` function
+	plot(jim)	plot the image geometry using the `MIRTjim.jim` function
 
 	Methods that return a new `ImageGeom:`
 
@@ -428,8 +428,8 @@ end
 
 
 """
-image_geom_plot(ig, how ; kwargs...)
-The `how` argument should be `jim` to be useful.
+    image_geom_plot(ig, how ; kwargs...)
+The `how` argument should be `MIRTjim.jim` to be useful.
 """
 image_geom_plot(ig::ImageGeom{2}, how::Function ; kwargs...) =
 	how(ig.x, ig.y, ig.mask, "(nx,ny)=$(ig.nx),$(ig.ny)" ; kwargs...)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -5,6 +5,7 @@ Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LinearMapsAA = "599c1a8e-b958-11e9-0d14-b1e6b2ecea07"
+MIRTjim = "170b2178-6dee-4cb0-8729-b3e8b57834cc"
 NFFT = "efe261a4-0d2b-5849-be55-fc731d526b0d"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -13,4 +14,5 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 LaTeXStrings = "1"
+MIRTjim = "0.6"
 Plots = "1.15"

--- a/test/fbp/cuboid_im.jl
+++ b/test/fbp/cuboid_im.jl
@@ -1,10 +1,11 @@
 # cuboid_im.jl
 
-using MIRT: cuboid_im, image_geom, jim
+using MIRT: cuboid_im, image_geom
+using MIRTjim: jim
 
 using Plots
 using Test: @test, @test_throws, @inferred
-#using MIRT: jim, downsample3, rotate2d
+#using MIRT: downsample3, rotate2d
 
 
 """

--- a/test/fbp/disk-phantom.jl
+++ b/test/fbp/disk-phantom.jl
@@ -1,6 +1,7 @@
 # disk-phantom.jl
 
-using MIRT: disk_phantom_params, ellipse_im, jim
+using MIRT: disk_phantom_params, ellipse_im
+using MIRTjim: jim
 using Test: @inferred
 
 

--- a/test/fbp/ellipse_im.jl
+++ b/test/fbp/ellipse_im.jl
@@ -1,7 +1,8 @@
 # ellipse_im.jl
 
 using MIRT: ellipse_im, ellipse_im_fast, ellipse_im_params
-using MIRT: image_geom, disk_phantom_params, shepp_logan_parameters, jim
+using MIRT: image_geom, disk_phantom_params, shepp_logan_parameters
+using MIRTjim: jim
 
 using Plots: plot
 #using Printf: @sprintf

--- a/test/fbp/ellipse_sino.jl
+++ b/test/fbp/ellipse_sino.jl
@@ -1,13 +1,14 @@
 # ellipse_sino.jl
 
 using MIRT: ellipse_sino
-using MIRT: image_geom, sino_geom, ellipse_im, jim, prompt
+using MIRT: image_geom, sino_geom, ellipse_im
+using MIRTjim: jim, prompt
 using Plots: plot, Plot
 using Test: @test, @inferred
 
 
 """
-`ellipse_sino_show()`
+    ellipse_sino_show()
 show examples
 
 To see more, use `MIRT.ellipse_sino_show(ip=2)`

--- a/test/fbp/ellipsoid_im.jl
+++ b/test/fbp/ellipsoid_im.jl
@@ -1,7 +1,8 @@
 # ellipsoid_im.jl
 
 using MIRT: ellipsoid_im, shepp_logan_3d_parameters
-using MIRT: image_geom, jim
+using MIRT: image_geom
+using MIRTjim: jim
 import MIRT: _ellipsoid_im_check_fov
 
 using Plots
@@ -9,7 +10,7 @@ using Test: @test, @test_throws
 
 
 """
-ellipsoid_im_show()
+    ellipsoid_im_show()
 """
 function ellipsoid_im_show(ig)
 	x1 = ellipsoid_im(ig, :spheroid)

--- a/test/fbp/image_geom.jl
+++ b/test/fbp/image_geom.jl
@@ -2,7 +2,7 @@
 
 using MIRT: ImageGeom, image_geom, cbct
 using MIRT: image_geom_ellipse
-using MIRT: jim
+using MIRTjim: jim
 using FillArrays: Trues
 
 using Test: @test, @testset, @test_throws, @inferred

--- a/test/fbp/rect_im.jl
+++ b/test/fbp/rect_im.jl
@@ -1,13 +1,14 @@
 # rect_im.jl
 
-using MIRT: rect_im, image_geom, jim
+using MIRT: rect_im, image_geom
+using MIRTjim: jim
 
 using Plots: plot
 using Test: @test, @test_throws, @inferred
 
 
 """
-rect_im_show()
+    rect_im_show()
 """
 function rect_im_show()
 	ig = image_geom(nx=2^8, ny=2^8, fov=100)

--- a/test/fbp/rect_sino.jl
+++ b/test/fbp/rect_sino.jl
@@ -1,14 +1,15 @@
 # rect_sino.jl
 
-using MIRT: rect_sino, sino_geom, jim
+using MIRT: rect_sino, sino_geom
 import MIRT: trapezoid
+using MIRTjim: jim
 
 using Plots: plot
 using Test: @test, @test_throws, @inferred
 
 
 """
-`rect_sino_show()`
+    rect_sino_show()
 show examples
 """
 function rect_sino_show( ;

--- a/test/fbp/sino_geom.jl
+++ b/test/fbp/sino_geom.jl
@@ -2,10 +2,11 @@
 
 using MIRT: sino_geom
 using MIRT: sino_geom_help, sino_geom_plot_grids
-using MIRT: image_geom, prompt
+using MIRT: image_geom
+using MIRTjim: prompt
 import MIRT: sino_geom_gamma_dfs
 
-using Plots: plot!, plot, scatter, gui
+using Plots: plot!, plot, scatter
 using Test: @test, @test_throws, @inferred
 
 
@@ -87,7 +88,7 @@ for ii = 1:nsg
 
 	sg.grid
 	sg.plot_grid(plot)
-#	gui(); prompt()
+#	prompt()
 
 	if sg isa SinoMoj
 		sg.d_moj(0)
@@ -100,7 +101,7 @@ for ii = 1:nsg
 	sg.unitv(ib=1, ia=2)
 
 	pl[ii] = plot(); sg.plot!(plot! ; ig=ig)
-#	gui(); prompt()
+#	prompt()
 end
 
 #@inferred todo

--- a/test/io/prompt.jl
+++ b/test/io/prompt.jl
@@ -1,11 +1,6 @@
 # prompt.jl
 
-using MIRT: prompt
+import MIRT # prompt
 using Test: @test
 
-
-_tmp = prompt(:state) # save current state
-prompt(:draw)
-@test prompt(:state) === :draw
-prompt()
-@test prompt(_tmp) isa Symbol # return to original state
+@test MIRT.prompt(:state) isa Symbol

--- a/test/io/z-test.jl
+++ b/test/io/z-test.jl
@@ -11,12 +11,6 @@ list = [
 "shows.jl"
 ]
 
-# todo: temporary work around for:
-# https://github.com/JeffFessler/MIRT.jl/issues/58
-if Base.Sys.iswindows()
-	list = list[1:(end-1)]
-end
-
 for file in list
 	@testset "$file" begin
 		include(file)

--- a/test/mri/coil_compress.jl
+++ b/test/mri/coil_compress.jl
@@ -1,7 +1,8 @@
 # coil_compress.jl
 
 using MIRT: ir_mri_coil_compress
-using MIRT: jim, prompt, ir_mri_sensemap_sim, ir_load_brainweb_t1_256
+using MIRTjim: jim, prompt
+using MIRT: ir_mri_sensemap_sim, ir_load_brainweb_t1_256
 import MIRT: snr2sigma
 
 using LinearAlgebra: svd, norm

--- a/test/mri/mri_objects.jl
+++ b/test/mri/mri_objects.jl
@@ -2,7 +2,8 @@
 
 using MIRT: mri_objects
 
-using MIRT: jim, image_geom, prompt, max_percent_diff
+using MIRTjim: jim, prompt
+using MIRT: image_geom, max_percent_diff
 import MIRT: mri_objects_trap
 using FFTW: fft, fftshift, ifftshift
 using Plots

--- a/test/mri/mri_trajectory.jl
+++ b/test/mri/mri_trajectory.jl
@@ -1,7 +1,7 @@
 # mri_trajectory.jl
 
 
-using MIRT: mri_trajectory image_geom_mri
+using MIRT: mri_trajectory, image_geom_mri
 using MIRTjim: prompt
 
 using Plots

--- a/test/mri/mri_trajectory.jl
+++ b/test/mri/mri_trajectory.jl
@@ -1,7 +1,8 @@
 # mri_trajectory.jl
 
 
-using MIRT: mri_trajectory, prompt, image_geom_mri
+using MIRT: mri_trajectory image_geom_mri
+using MIRTjim: prompt
 
 using Plots
 using Test: @test

--- a/test/mri/sensemap-sim.jl
+++ b/test/mri/sensemap-sim.jl
@@ -1,7 +1,8 @@
 # sensemap-sim.jl
 
 using MIRT: ir_mri_sensemap_sim
-using MIRT: jim, prompt, image_geom, ndgrid
+using MIRTjim: jim, prompt
+using MIRT: image_geom, ndgrid
 import MIRT: ir_mri_smap_r
 import MIRT: ir_mri_smap1
 
@@ -76,7 +77,7 @@ end
 
 
 """
-ellipke_plot()
+    ellipke_plot()
 """
 function ellipke_plot()
 	m = LinRange(0,1,101)

--- a/test/plot/jim.jl
+++ b/test/plot/jim.jl
@@ -1,27 +1,6 @@
 # jim.jl
 
-using MIRT: jim
-using LaTeXStrings
+import MIRT # jim
 using Test: @test, @test_throws
 
-
-#jim()
-jim(:keys)
-jim(:clim)
-@test jim(:defs) isa Dict
-
-@test_throws String jim(:bad)
-
-jim(ones(4,3), title="test2", xlabel=L"x")
-jim(rand(4,3,5), title=L"test3 x^2_i")
-jim(1:4, 5:9, zeros(4,5), title="test3", ylabel=L"y")
-jim(zeros(4,5), x=1:4, y=5:9, title="test3")
-jim(rand(6,4), fft0=true)
-jim(x=1:4, y=5:9, rand(4,5), title="test4")
-jim(x=-9:9, y=9:-1:-9, (-9:9) * (abs.((9:-1:-9) .- 5) .< 3)', title="rev")
-jim(ones(3,3)) # uniform
-jim(:abswarn, false)
-jim(complex(rand(4,3)))
-jim(complex(rand(4,3)), "complex")
-jim(:abswarn, true)
-jim(rand(4,5), color=:hsv)
+@test MIRT.jim(:defs) isa Dict

--- a/test/regularize/Aodwt.jl
+++ b/test/regularize/Aodwt.jl
@@ -1,14 +1,14 @@
 # Aodwt.jl
 
 using MIRT: Aodwt
-using MIRT: jim
+using MIRTjim: jim
 
 using LinearMapsAA: LinearMapAM, LinearMapAO
 using Test: @test
 
 
 """
-Aodwt_show( ; dims::Dims=(64,32), level::Int=3)
+    Aodwt_show( ; dims::Dims=(64,32), level::Int=3)
 show scales
 """
 function Aodwt_show( ; dims::Dims = (64, 32), level::Int=3)


### PR DESCRIPTION
The test suite was using `MIRT.jim` instead of `MIRTjim.jim` and that led to a lot of noisy warnings.
Likewise for `prompt`.
This PR has the tests mostly use the `MIRTjim` versions so that there are just a few warnings.

It also eliminates a no-longer-needed workaround related to the windows `rm` issue
https://github.com/JeffFessler/MIRT.jl/issues/58

There are no changes to `src/` except for comments, so no version bump.