### PR TITLE
Fix for ellipse_im with nonzero rotation

### DIFF
--- a/src/fbp/ellipse_im.jl
+++ b/src/fbp/ellipse_im.jl
@@ -146,8 +146,8 @@ function ellipse_im_fast!(phantom, nx, ny, params_in, dx, dy,
         th = deg2rad(rot)
 		cx = params[:,1]
 		cy = params[:,2]
-		params[:,1] = cx * cos(th) + cy * sin(th)
-		params[:,2] = -cx * sin(th) + cy * cos(th)
+		params[:,1] = cx * cos(th) - cy * sin(th)
+		params[:,2] = cx * sin(th) + cy * cos(th)
 		params[:,5] .+= rot
 	end
 


### PR DESCRIPTION
Test code:
```julia
import MIRT: ellipse_im, jim
import ImageTransformations: imrotate, Linear
jim([ ellipse_im(256,256; rot=0); 
      ellipse_im(256,256; rot=45);
      imrotate(ellipse_im(256,256; rot=0), π/4, (256,256), Linear(), 0.0)], colorbar=:none)
```
Before on the current HEAD of master:
![Screen Shot 2021-07-13 at 1 40 33 PM](https://user-images.githubusercontent.com/10264985/125502326-3cfbe7ae-569d-4a9a-bb75-3dc6d4dc11da.png)

After changes:
![Screen Shot 2021-07-13 at 1 46 32 PM](https://user-images.githubusercontent.com/10264985/125502364-5e333318-a67e-44c7-9d0c-911296f593fd.png)
