### PR TITLE
Fix `snr2sigma`

### DIFF
--- a/src/mri/coil_compress.jl
+++ b/src/mri/coil_compress.jl
@@ -50,8 +50,12 @@ end
 
 """
     snr2sigma(db, yb)
-convert SNR in dB to noise σ for complex gaussian noise
+Convert SNR in dB to noise σ for complex gaussian noise.
+No `sqrt(2)` factors is needed here
+because `randn(Complex{Float})`
+already accounts for that.
+(See `randn` documentation.)
 """
 function snr2sigma(db, yb::AbstractArray{<:Complex})
-    10^(-db/20) * norm(yb) / sqrt(length(yb)) / sqrt(2)
+    return 10^(-db/20) * norm(yb) / sqrt(length(yb))
 end

--- a/test/mri/coil_compress.jl
+++ b/test/mri/coil_compress.jl
@@ -10,6 +10,15 @@ using Plots: plot, plot!, scatter, scatter!
 using Test: @inferred
 
 
+# snr2sigma test
+yt = rand(ComplexF32, 2^18)
+db = 50
+σ = snr2sigma(db, yt)
+yn = yt + σ * randn(ComplexF32, length(yt))
+snr = 10*log10(sum(abs2, yt) / sum(abs2, yt - yn))
+@test abs(snr - db) < 0.1
+
+
 xtrue = ir_load_brainweb_t1_256()
 (nx, ny) = size(xtrue)
 ncoil = 8


### PR DESCRIPTION
Because `randn` for complex data in Julia already adjusts for sqrt(2).